### PR TITLE
[Bug Fixes] np.bool and fit_sample deprecated 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,7 +78,7 @@ Example Usage
             'k_neighbors': 10
         }
     )
-    X_resampled, y_resampled = kmeans_smote.fit_sample(X, y)
+    X_resampled, y_resampled = kmeans_smote.fit_resample(X, y)
 
     [print('Class {} has {} instances after oversampling'.format(label, count))
      for label, count in zip(*np.unique(y_resampled, return_counts=True))]

--- a/kmeans_smote.py
+++ b/kmeans_smote.py
@@ -210,7 +210,7 @@ class KMeansSMOTE(BaseOverSampler):
             if (imbalance_ratio < imbalance_ratio_threshold) and (minority_count > 1):
                 distances = euclidean_distances(cluster[mask])
                 non_diagonal_distances = distances[
-                    ~np.eye(distances.shape[0], dtype=np.bool)
+                    ~np.eye(distances.shape[0], dtype=np.bool_)
                 ]
                 average_minority_distance = np.mean( non_diagonal_distances )
                 if average_minority_distance is 0: average_minority_distance = 1e-1 # to avoid division by 0

--- a/kmeans_smote.py
+++ b/kmeans_smote.py
@@ -309,7 +309,7 @@ class KMeansSMOTE(BaseOverSampler):
                             # ignore warnings about minority class getting bigger than majority class
                             # since this would only be true within this cluster
                             warnings.filterwarnings(action='ignore', category=UserWarning, message=r'After over-sampling, the number of samples \(.*\) in class .* will be larger than the number of samples in the majority class \(class #.* \-\> .*\)')
-                            cluster_resampled_X, cluster_resampled_y = oversampler.fit_sample(cluster_X, cluster_y)
+                            cluster_resampled_X, cluster_resampled_y = oversampler.fit_resample(cluster_X, cluster_y)
 
                         if remove_index > -1:
                             # since SMOTE's results are ordered the same way as the data passed into it,

--- a/kmeans_smote.py
+++ b/kmeans_smote.py
@@ -329,7 +329,7 @@ class KMeansSMOTE(BaseOverSampler):
                 minority_count = np.count_nonzero(y == minority_class_label)
                 smote_args = self._validate_smote_args(smote_args, minority_count)
                 oversampler = SMOTE(**smote_args)
-                X_smote, y_smote = oversampler.fit_sample(X, y)
+                X_smote, y_smote = oversampler.fit_resample(X, y)
                 resampled.append((
                     X_smote[y.size:,:],
                     y_smote[y.size:]))


### PR DESCRIPTION
Issue with numpy.bool_
- The usage of numpy.bool has been deprecated as of Numpy 1.20. Instead, it's recommended to either use the built in python bool or use the numpy scalar numpy.bool_
- Thus in this PR I have used numpy.bool_

Issue with fit_sample
- fit_sample is deprecated in SMOTE and renamed as fit_resample and thus changes have been made accordingly
